### PR TITLE
[COMPIL] Fix

### DIFF
--- a/RAPter/CMakeLists.txt
+++ b/RAPter/CMakeLists.txt
@@ -14,7 +14,7 @@ SET( PCL_DIR "${THIRD_PARTY_DIR}/pcl-trunk2/install/share/pcl-1.8/"
         CACHE FILEPATH "Folder containing \"PCLConfig.cmake\", usually \"{PCL_INSTALL_DIR}/share/pcl-x.x/\"." )
 # BONMIN
 SET( PATH_BONMIN_DIR "${THIRD_PARTY_DIR}/CoinBonmin-stable/build/"
-    CACHE FILEPATH "Folder containing the compiled Bonmin libraries")
+    CACHE FILEPATH "Folder containing the compiled Bonmin libraries" FORCE)
 #SET( PATH_BONMIN_DIR "${THIRD_PARTY_DIR}/Bonmin-1.8.0-lapack/")
 
 ## QCQPCPP

--- a/RAPter/external/qcqpcpp/include/qcqpcpp/bonminOptProblem.h
+++ b/RAPter/external/qcqpcpp/include/qcqpcpp/bonminOptProblem.h
@@ -691,7 +691,7 @@ BonminTMINLP<_Scalar>::get_starting_point( Ipopt::Index    n
 
                 x[ j ] = (*real_distribution)( gen );
 
-                if ( isinf(x[j]) )
+                if ( std::isinf(x[j]) )
                     std::cerr << "[" << __func__ << "]: " << "warning, returning inf as starting point x0[" << j << "]..." << std::endl;
 
                 if ( _delegate.isDebug() )


### PR DESCRIPTION
A `std::` was missing.  
With cmake, it's better to force environment path variables setting.